### PR TITLE
Add LCSH block to subject

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -43,6 +43,8 @@
 		<meta property="term" refines="#subject-3">sh2007102172</meta>
 		<meta property="authority" refines="#subject-4">LCSH</meta>
 		<meta property="term" refines="#subject-4">sh2008107221</meta>
+		<meta property="authority" refines="#subject-5">LCSH</meta>
+		<meta property="term" refines="#subject-5">Unknown</meta>
 		<meta property="se:subject">Fiction</meta>
 		<meta id="collection-1" property="belongs-to-collection">The Guardian’s Best 100 Novels in English (2015)</meta>
 		<meta property="collection-type" refines="#collection-1">set</meta>


### PR DESCRIPTION
No “Conformity -- Fiction” in LCSH, but LOC lists *Babbitt* under “Conformity.”